### PR TITLE
Returnere 200 på /isAlive og /isReady

### DIFF
--- a/src/main/java/nais/nav/no/demo/DemoApplication.java
+++ b/src/main/java/nais/nav/no/demo/DemoApplication.java
@@ -20,5 +20,15 @@ public class DemoApplication {
     public String hello(@RequestParam(value="name", defaultValue = "World") String name) {
         return String.format("Hello, %s!", name);
     }
+    
+    @RequestMapping(value="/isAlive",method = RequestMethod.GET)
+    public String isAlive() {
+        return "Alive and kicking!";
+    }
 
+    @RequestMapping(value="/isReady",method = RequestMethod.GET)
+    public String isReady() {
+        return "Ready to go!";
+    }
+    
 }


### PR DESCRIPTION
Java applikasjoner vil ikke starte på standard navikt/java docker image hvis de ikke returnerer statuskode 200 på GET /isAlive og GET /isReady